### PR TITLE
Change intercept position

### DIFF
--- a/src/local.js
+++ b/src/local.js
@@ -20,7 +20,7 @@ function addBias(arr) {
     throw new Error(`Expected every item of ${arr} to be an array`);
   }
 
-  return arr.map(row => row.concat(1));
+  return arr.map(row => [1].concat(row));
 }
 
 /**

--- a/test/local.js
+++ b/test/local.js
@@ -51,7 +51,7 @@ tape('addBias', (t) => {
     'throws with non-array item'
   );
   const r = local.addBias([[1, 2, 3], [4, 5, 6]]);
-  t.deepEquals(r, [[1, 2, 3, 1], [4, 5, 6, 1]], 'bias adds');
+  t.deepEquals(r, [[1, 1, 2, 3], [1, 4, 5, 6]], 'bias adds');
   t.end();
 });
 
@@ -126,7 +126,7 @@ tape('preprocess', (t) => {
 
       t.deepEqual(
         result.biasedX,
-        [[28, 1, 1], [29, -1, 1], [31, 1, 1]],
+        [[1, 28, 1], [1, 29, -1], [1, 31, 1]],
         'transforms files\' tags to co-variates in `biasedX`'
       );
       t.deepEqual(


### PR DESCRIPTION
Change the intercept(bias) position as the first column. Make bias position consistent for both single-shot and multi-shot. So, the mappings to statistic output table are same for both regressions. Please have a review @swashcap  