### PR TITLE
Alpha-sort FreeSurfer ROIs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "tape": "^4.5.1"
   },
   "dependencies": {
+    "alphanum-sort": "^1.0.2",
     "distributions": "^1.0.0",
     "freesurfer-parser": "^0.0.2",
     "jstat": "^1.5.2",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const alphanumSort = require('alphanum-sort');
 const FreeSurfer = require('freesurfer-parser');
 const pkg = require('../package.json');
 const localRunner = require('./local');
@@ -30,7 +31,10 @@ module.exports = {
         help: 'Select Freesurfer region(s) of interest',
         label: 'Freesurfer ROI',
         type: 'select',
-        values: FreeSurfer.validFields,
+        values: alphanumSort(
+          FreeSurfer.validFields.filter(field => field !== 'header'),
+          { insensitive: true }
+        ),
       }, {
         defaultValue: DEFAULT_MAX_ITERATIONS,
         label: 'Iteration count',


### PR DESCRIPTION
* **Problem:** FreeSurfer ROIs are difficult to find in the UI (see MRN-Code/coinstac#150).
* **Solution:** Alpha-sort ROIs and remove the “header” field.
* **Testing:** View computation in UI.